### PR TITLE
bouncer.py: changes DM to ephemeral message for web settings URL

### DIFF
--- a/source/bouncer.py
+++ b/source/bouncer.py
@@ -107,10 +107,9 @@ async def web_channel_edit(ctx):
     session.add(SettingsAccessRequest(key, ctx.guild.id, ctx.channel.id,
                                       ctx.guild.name, ctx.channel.name))
     session.commit()
-    await ctx.author.send(
-        "Yo! To edit your Bouncer settings for channel `#{}` in server `{}`, click {}/settings?key={}. This URL can only be used once!".format(
-            ctx.channel.name, ctx.guild.name, bouncer_domain, key))
-    await ctx.respond("Check your DMs for your one-time link to edit this channel on the web.")
+    await ctx.respond(
+        "Yo! To edit Bouncer settings for channel `#{}`, click {}/settings?key={}. This URL can only be used once!".format(
+            ctx.channel.name, bouncer_domain, key), ephemeral=True)
 
 
 @bot.slash_command()


### PR DESCRIPTION
Fixes #206 
* Note: Ephemeral message will self-delete after 15 minutes, when dismissed, or when Discord window is refreshed.

<img width="544" alt="Screenshot 2023-03-13 at 2 41 54 PM" src="https://user-images.githubusercontent.com/100495150/224839127-f5a2537b-d9d2-4f79-8d1b-dc46d7d4f15a.png">

